### PR TITLE
Updated _getLib function to set the directory based on GetCurrentTemp…

### DIFF
--- a/models/CbJGroupsCluster.cfc
+++ b/models/CbJGroupsCluster.cfc
@@ -177,7 +177,7 @@ component {
 	}
 
 	private array function _getLib() {
-		return DirectoryList( ExpandPath( "/cbjgroups/lib/" ), false, "path" );
+		return DirectoryList( ExpandPath( GetDirectoryFromPath(GetCurrentTemplatePath()) & "../lib" ), false, "path" );
 	}
 
 	private any function _setupApplicationContext() {


### PR DESCRIPTION
…latePath()

This fixes the bug that jar files are not found when installed in the /application/modules folder